### PR TITLE
Added the ability to allow optional Index name overrides

### DIFF
--- a/cloudwatch-logs-to-elastic-cloud/README.md
+++ b/cloudwatch-logs-to-elastic-cloud/README.md
@@ -38,6 +38,7 @@ Set the following optional environment variables for the Lambda function:
 
 | Key                                  | Value                                                      |
 | ------------------------------------ | ---------------------------------------------------------- |
+| index                                | The Elasticsearch index name to override logGroup.         |
 | pipeline                             | The Elasticsearch ingest pipeline to use.                  |
 | piperegexp                           | RegExp matched with the log group if the pipeline applies. |
 | pipefields                           | Required fields for the pipeline to add if missing, e.g.:  |

--- a/cloudwatch-logs-to-elastic-cloud/index.js
+++ b/cloudwatch-logs-to-elastic-cloud/index.js
@@ -157,7 +157,7 @@ function buildSource(logEvent, payload, hasPipeline) {
  */
 function transform(payload, hasPipeline) {
   let bulkRequestBody = ''
-  const index = payload.logGroup
+  const index = ENV.index ? ENV.index : payload.logGroup
     .replace(/\W+|_+/g, '-')
     .replace(/^-/, '')
     .toLowerCase()


### PR DESCRIPTION
### cloudwatch-logs-to-elastic-cloud
Currently using this in a nonprod environment without issue.

The change allows you to set an environment flag `index` that overrides the default logGroup index naming scheme. 
